### PR TITLE
Fix meta args cascade arguments

### DIFF
--- a/cognac_gen.sh
+++ b/cognac_gen.sh
@@ -339,7 +339,8 @@ EOF
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS()
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -355,32 +356,7 @@ EOF
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS();
 			     }
 EOF
 

--- a/main_tpl.c
+++ b/main_tpl.c
@@ -61,6 +61,33 @@
 		if (f) {fprintf(stderr, args);  return -1;}	\
 	} while(0)
 
+#define META_ARGS()                                                     \
+	if (!strcmp(aa, "--file")) {                                        \
+		TRY(i + 3 >= ac, "file name require");                          \
+		++incr;                                                         \
+		aa = read_file(files_cnt, av[i + 3], 0);                        \
+		STRY(!aa);                                                      \
+	} else if (!strcmp(aa, "--jsonstr-file")) {                         \
+		TRY(i + 3 >= ac, "file name require");                          \
+		++incr;                                                         \
+		aa = read_file(files_cnt, av[i + 3], 1);                        \
+		STRY(!aa);                                                      \
+	} else if (!strcmp(aa, "--var")) {                                  \
+		TRY(i + 3 >= ac, "var name require");                           \
+		int var_found = 0;                                              \
+		for (int j = 0; j < nb_cli_vars; ++j) {                         \
+			if (!strcmp(cli_vars[j].name, av[i + 3])) {                 \
+				var_found = 1;                                          \
+				aa = cli_vars[j].val;                                   \
+			}                                                           \
+		}                                                               \
+		TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]); \
+		++incr;                                                         \
+		STRY(!aa);                                                      \
+	} else {                                                            \
+		aa = 0;                                                         \
+		incr = 1;                                                       \
+	}
 
 #define VAR_NAME_SIZE 128
 #define VAR_VAL_SIZE 512


### PR DESCRIPTION
Add support for `--var` and other inside cascade notation.
For example: `CreateTags --ResourceIds[] --var net --Tags.0.Key "test" ..Value --var net`