### PR TITLE
🩹fix: C SDK and OAPI-CLI return 0 (ok) when API call fail

### DIFF
--- a/cognac_gen.sh
+++ b/cognac_gen.sh
@@ -485,17 +485,22 @@ EOF
 			    goto ${snake_l}_arg;
 		     }
 		     cret = osc_$snake_l(&e, &r, &a);
-            	     TRY(cret, "fail to call $l: %s\n", curl_easy_strerror(cret));
-		     CHK_BAD_RET(!r.buf, "connection sucessful, but empty responce\n");
 		     jobj = NULL;
-		     if (program_flag & OAPI_RAW_OUTPUT)
-		             puts(r.buf);
-		     else {
+		     if (program_flag & OAPI_RAW_OUTPUT) {
+		     	if (r.buf)
+				puts(r.buf);
+			else if (cret)
+				fprintf(stderr, "fail to call $l: %s", curl_easy_strerror(cret));
+		     } else if (r.buf) {
 			     jobj = json_tokener_parse(r.buf);
 			     puts(json_object_to_json_string_ext(jobj,
 					JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_NOSLASHESCAPE |
 					color_flag));
-		     }
+		     } else fprintf(stderr, "Called $l (%s) and received an empty body. ", cret ? "failed" : "succeeded");
+
+                     if (cret)
+		     	return cret;
+
 		     while (i + 1 < ac && !strcmp(av[i + 1], "--set-var")) {
 		     	     ++i;
 			     TRY(i + 1 >= ac, "--set-var require an argument");

--- a/function.c
+++ b/function.c
@@ -40,6 +40,16 @@ int osc_____snake_func____(struct osc_env *e, struct osc_str *out, struct osc___
 	  printf("<Data send to curl>\n%s\n</Data send to curl>\n", data.buf);
 	}
 	res = curl_easy_perform(e->c);
+	if (res != CURLE_OK)
+		goto out;
+
+	long statuscode = 200;
+	res = curl_easy_getinfo(e->c, CURLINFO_RESPONSE_CODE, &statuscode);
+	if (res != CURLE_OK)
+		goto out;
+
+	if (statuscode >= 400)
+		res = 1;
 out:
 	osc_deinit_str(&data);
 	return res;


### PR DESCRIPTION
HTTP Status code is ignored by default by libcurl

Closes [OAPI-CLI issue #83](https://github.com/outscale/oapi-cli/issues/83)